### PR TITLE
Loosen `oj` dependency

### DIFF
--- a/jsonlint.gemspec
+++ b/jsonlint.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'oj', '~> 2'
+  spec.add_dependency 'oj'
   spec.add_dependency 'trollop', '~> 2'
 
   spec.add_development_dependency "bundler", "~> 1.6"


### PR DESCRIPTION
This allows `jsonlint` to be used with newer versions of `oj`.