### PR TITLE
Trollop gem has been renamed to Optimist

### DIFF
--- a/jsonlint.gemspec
+++ b/jsonlint.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'oj', '~> 2'
-  spec.add_dependency 'trollop', '~> 2'
+  spec.add_dependency 'optimist', '~> 3'
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"

--- a/lib/jsonlint/cli.rb
+++ b/lib/jsonlint/cli.rb
@@ -1,4 +1,4 @@
-require 'trollop'
+require 'optimist'
 
 module JsonLint
   class CLI
@@ -11,7 +11,7 @@ module JsonLint
 
       files_to_check = @argv
 
-      Trollop::die 'need at least one JSON file to check' if files_to_check.empty?
+      Optimist::die 'need at least one JSON file to check' if files_to_check.empty?
 
       linter = JsonLint::Linter.new
       begin
@@ -36,7 +36,7 @@ module JsonLint
     private
 
     def parse_options
-      @opts = Trollop.options(@argv) do
+      @opts = Optimist.options(@argv) do
         banner 'Usage: jsonlint [options] file1.json [file2.json ...]'
         version(JsonLint::VERSION)
         banner ''


### PR DESCRIPTION
jsonlint CLI started to produce following error:

`
[DEPRECATION] This gem has been renamed to optimist and will no longer be supported. Please switch to optimist as soon as possible.
`
- Switchted to latest version of Optimist gem
- Tests are passing.